### PR TITLE
Added tradeStream to SpotApi

### DIFF
--- a/src/e2e/scala/io/github/paoloboni/SpotE2ETests.scala
+++ b/src/e2e/scala/io/github/paoloboni/SpotE2ETests.scala
@@ -3,7 +3,7 @@ package io.github.paoloboni
 import cats.effect.IO
 import cats.effect.testing.scalatest.AsyncIOSpec
 import cats.implicits._
-import io.github.paoloboni.binance.common.response.{BookTicker, DiffDepthStream, KLineStream, Level, PartialDepthStream}
+import io.github.paoloboni.binance.common.response.{BookTicker, DiffDepthStream, TradeStream, KLineStream, Level, PartialDepthStream}
 import io.github.paoloboni.binance.common.{Interval, OrderSide, SpotConfig}
 import io.github.paoloboni.binance.spot._
 import io.github.paoloboni.binance.spot.parameters._

--- a/src/e2e/scala/io/github/paoloboni/SpotE2ETests.scala
+++ b/src/e2e/scala/io/github/paoloboni/SpotE2ETests.scala
@@ -115,6 +115,14 @@ class SpotE2ETests extends AsyncFreeSpec with AsyncIOSpec with Matchers with Env
       .asserting(_ shouldBe "OK")
   }
 
+  "tradeStreams" in {
+    BinanceClient
+      .createSpotClient[IO](config)
+      .use(_.tradeStreams("btcusdt").take(1).compile.toList)
+      .timeout(30.seconds)
+      .asserting(_.loneElement shouldBe a[TradeStream])
+  }
+
   "kLineStreams" in {
     BinanceClient
       .createSpotClient[IO](config)

--- a/src/main/scala/io/github/paoloboni/binance/common/response/TradeStream.scala
+++ b/src/main/scala/io/github/paoloboni/binance/common/response/TradeStream.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2021 Paolo Boni
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package io.github.paoloboni.binance.common.response
+
+final case class TradeStream(
+    e: String,     // Event type
+    E: Long,       // Event time
+    s: String,     // Symbol
+    t: Long,       // Trade ID
+    p: BigDecimal, // Price
+    q: BigDecimal, // Quantity
+    b: Long,       // Buyer order ID
+    a: Long,       // Seller order ID
+    T: Long,       // Trade time
+    
+    m: Boolean,    // Is the buyer the market maker?
+    M: Boolean     // Ignore
+)

--- a/src/main/scala/io/github/paoloboni/binance/common/response/TradeStream.scala
+++ b/src/main/scala/io/github/paoloboni/binance/common/response/TradeStream.scala
@@ -31,7 +31,6 @@ final case class TradeStream(
     b: Long,       // Buyer order ID
     a: Long,       // Seller order ID
     T: Long,       // Trade time
-    
     m: Boolean,    // Is the buyer the market maker?
     M: Boolean     // Ignore
 )

--- a/src/main/scala/io/github/paoloboni/binance/spot/SpotApi.scala
+++ b/src/main/scala/io/github/paoloboni/binance/spot/SpotApi.scala
@@ -236,6 +236,21 @@ final case class SpotApi[F[_]: Logger](
     } yield ()
   }
 
+  /** The Trade Streams push raw trade information; each trade has a unique buyer and seller.
+    *
+    * @param symbol
+    *   the symbol
+    * @return
+    *   a stream of trades
+    */
+  def tradeStreams(symbol: String): Stream[F, TradeStream] =
+    for {
+      uri <- Stream.eval(
+        F.fromEither(Try(uri"${config.wsBaseUrl}/ws/${symbol.toLowerCase}@trade").toEither)
+      )
+      stream <- client.ws[TradeStream](uri)
+    } yield stream
+
   /** The Kline/Candlestick Stream push updates to the current klines/candlestick every second.
     *
     * @param symbol

--- a/src/test/scala/io/github/paoloboni/binance/SpotClientIntegrationTest.scala
+++ b/src/test/scala/io/github/paoloboni/binance/SpotClientIntegrationTest.scala
@@ -751,17 +751,17 @@ class SpotClientIntegrationTest extends AnyFreeSpec with Matchers with TestClien
       } yield result
 
       test.timeout(30.seconds).unsafeRunSync() should contain only TradeStream(
-        e = "trade",     
-        E = 123456789,   
-        s = "BNBBTC",    
-        t = 12345,       
-        p = 0.001,     
-        q = 100,       
-        b = 88,          
-        a = 50,          
-        T = 123456785,   
-        m = true,        
-        M = true         
+        e = "trade",
+        E = 123456789,
+        s = "BNBBTC",
+        t = 12345,
+        p = 0.001,
+        q = 100,
+        b = 88,
+        a = 50,
+        T = 123456785,
+        m = true,
+        M = true
       )
     }
   }


### PR DESCRIPTION
This adds tradeStreams to SpotApi. Same as in https://binance-docs.github.io/apidocs/spot/en/#trade-streams