### PR TITLE
Allow finalising backgrounded websocket requests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ lazy val EndToEndTest = config("e2e") extend Test
 lazy val e2eSettings =
   inConfig(EndToEndTest)(Defaults.testSettings) ++
     Seq(
-      EndToEndTest / fork              := false,
+      EndToEndTest / fork              := true,
       EndToEndTest / parallelExecution := false,
       EndToEndTest / scalaSource       := baseDirectory.value / "src" / "e2e" / "scala"
     )

--- a/src/e2e/scala/io/github/paoloboni/BaseE2ETest.scala
+++ b/src/e2e/scala/io/github/paoloboni/BaseE2ETest.scala
@@ -16,6 +16,8 @@ abstract class BaseE2ETest[API]
     with LoneElement
     with CatsResourceIO[API] {
 
+  implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
+
   override protected val ResourceTimeout: Duration = 30.seconds
 
   def config: BinanceConfig.Aux[IO, API]


### PR DESCRIPTION
When restarting streams frequently, you run into the issue where you can no longer create additional resources, with the following error. 

```shell
[info] 23:18:20.812 [io-compute-2] DEBUG org.asynchttpclient.netty.request.NettyRequestSender - Too many connections: 20
[info] org.asynchttpclient.exception.TooManyConnectionsException: Too many connections: 20
[info]  at org.asynchttpclient.netty.channel.MaxConnectionSemaphore.acquireChannelLock(Unknown Source)
[info]  at async @ 
```

This PR allows the backgrounded fiber to be cleaned up properly when the stream has been finalised, allowing the client resource being released back to the pool.