### PR TITLE
Fix indefinite blocking with rate limiter

### DIFF
--- a/src/main/scala/io/github/paoloboni/http/HttpClient.scala
+++ b/src/main/scala/io/github/paoloboni/http/HttpClient.scala
@@ -96,7 +96,7 @@ sealed class HttpClient[F[_]: Logger](implicit
           case WebSocketFrame.Text(payload, _, _) =>
             (decode[DataFrame](payload) match {
               case Left(ex) =>
-                Logger[F].error(ex)("Failed to decode frame: " + payload) *> q.offer(None) // stopping
+                Logger[F].error(ex)("Failed to decode frame: " + payload) *> q.offer(Some(Left(ex))) // stopping
               case Right(decoded) =>
                 q.offer(Some(Right(decoded)))
             }) *> F.pure(None)

--- a/src/main/scala/io/github/paoloboni/http/ratelimit/RateLimiter.scala
+++ b/src/main/scala/io/github/paoloboni/http/ratelimit/RateLimiter.scala
@@ -50,8 +50,8 @@ object RateLimiter {
         _ <- Stream.awakeDelay[F](period).evalMap(_ => queue.take.flatten).repeat.compile.drain.background
       } yield {
         new RateLimiter[F] {
-          override def rateLimit[T](effect: => F[T]): F[T] = Deferred[F, T].flatMap { p =>
-            queue.offer(F.defer(effect.flatTap(p.complete).void)) *> p.get
+          override def rateLimit[T](effect: => F[T]): F[T] = Deferred[F, Either[Throwable, T]].flatMap { p =>
+            queue.offer(effect.attempt.flatMap(p.complete).void) *> p.get.flatMap(_.liftTo[F])
           }
           override val limitType: RateLimitType = `type`
         }

--- a/src/test/scala/io/github/paoloboni/http/ratelimit/RateLimiterTest.scala
+++ b/src/test/scala/io/github/paoloboni/http/ratelimit/RateLimiterTest.scala
@@ -102,7 +102,7 @@ object RateLimiterTest extends SimpleIOSuite {
       }
   }
 
-  test("it should allow error to be propagated back to the caller".only) {
+  test("it should allow error to be bubble up back to the caller") {
     val perSecond     = 1 // period = 1.second
     val testThrowable = new Throwable("Request Error")
 

--- a/src/test/scala/io/github/paoloboni/http/ratelimit/RateLimiterTest.scala
+++ b/src/test/scala/io/github/paoloboni/http/ratelimit/RateLimiterTest.scala
@@ -112,11 +112,11 @@ object RateLimiterTest extends SimpleIOSuite {
           .use(rateLimiter =>
             rateLimiter
               .await(IO.raiseError[Throwable](testThrowable))
-              .handleErrorWith(IO.pure)
+              .attempt
           )
       )
       .map { case (res) =>
-        expect.same(res, testThrowable)
+        expect(res == Left(testThrowable))
       }
   }
 }


### PR DESCRIPTION
Fixes https://github.com/paoloboni/binance-scala-client/issues/260 

Issue was that upon request error, the deferred promise was never being completed. 
Also a note that the caller side requesting the rate limited job doesn't execute the job but the background stream does. In this case error would happen in the background stream and the stream would close but the caller is still waiting for the promise. 

By using `Either[Throwable, T]` we can complete the deferred promise on both success and error cases avoid the hang.