### PR TITLE
Flesh out some detail around kline stream update intervals

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ libraryDependencies += "io.github.paoloboni" %% "binance-scala-client" % "<versi
 * [Order book](https://binance-docs.github.io/apidocs/spot/en/#order-book): Order book depth on a symbol
 
 #### WebSocket
-* [Kline/Candlestick Streams](https://binance-docs.github.io/apidocs/spot/en/#kline-candlestick-streams): The Kline/Candlestick Stream push updates to the current klines/candlestick every second.
+* [Kline/Candlestick Streams](https://binance-docs.github.io/apidocs/spot/en/#kline-candlestick-streams): The Kline/Candlestick Stream push updates to the current klines/candlestick every two seconds.
 * [Diff. Depth Stream](https://binance-docs.github.io/apidocs/spot/en/#diff-depth-stream): Order book price and quantity depth updates used to locally manage an order book.
 * [All Book Tickers Stream](https://binance-docs.github.io/apidocs/spot/en/#all-book-tickers-stream): Pushes any update to the best bid or ask's price or quantity in real-time for all symbols.
 * [Partial Book Depth Streams](https://binance-docs.github.io/apidocs/spot/en/#partial-book-depth-streams): Top bids and asks.

--- a/src/main/scala/io/github/paoloboni/binance/common/response/KLineStream.scala
+++ b/src/main/scala/io/github/paoloboni/binance/common/response/KLineStream.scala
@@ -27,16 +27,16 @@ case class KLineStreamPayload(
     t: Long,       // Kline start time
     T: Long,       // Kline close time
     s: String,     // Symbol
-    i: Interval,   // Interval. The time period until a kline will close and next opens. 
+    i: Interval,   // Interval. The time period until a kline will close and next opens.
     f: Long,       // First trade ID
     L: Long,       // Last trade ID
-    o: BigDecimal, // Open price. Resets each time a kline is opened but otherwise remains stable 
+    o: BigDecimal, // Open price. Resets each time a kline is opened but otherwise remains stable
     c: BigDecimal, // Close price. When kline opened is same as open price, then updates progressively each stream update until close.
     h: BigDecimal, // High price. Updates progressively each stream update until close
     l: BigDecimal, // Low price. Updates progressively each stream update until close
     v: BigDecimal, // Base asset volume
     n: Int,        // Number of trades
-    x: Boolean,    // Is this kline closed on this stream update? When closed, volume and trade counter reset to zero and a new open price is set
+    x: Boolean, // Is this kline closed on this stream update? When closed, volume and trade counter reset to zero and a new open price is set
     q: BigDecimal, // Quote asset volume
     V: BigDecimal, // Taker buy base asset volume
     Q: BigDecimal  // Taker buy quote asset volume

--- a/src/main/scala/io/github/paoloboni/binance/common/response/KLineStream.scala
+++ b/src/main/scala/io/github/paoloboni/binance/common/response/KLineStream.scala
@@ -27,16 +27,16 @@ case class KLineStreamPayload(
     t: Long,       // Kline start time
     T: Long,       // Kline close time
     s: String,     // Symbol
-    i: Interval,   // Interval
+    i: Interval,   // Interval. The time period until a kline will close and next opens. 
     f: Long,       // First trade ID
     L: Long,       // Last trade ID
-    o: BigDecimal, // Open price
-    c: BigDecimal, // Close price
-    h: BigDecimal, // High price
-    l: BigDecimal, // Low price
+    o: BigDecimal, // Open price. Resets each time a kline is opened but otherwise remains stable 
+    c: BigDecimal, // Close price. When kline opened is same as open price, then updates progressively each stream update until close.
+    h: BigDecimal, // High price. Updates progressively each stream update until close
+    l: BigDecimal, // Low price. Updates progressively each stream update until close
     v: BigDecimal, // Base asset volume
     n: Int,        // Number of trades
-    x: Boolean,    // Is this kline closed?
+    x: Boolean,    // Is this kline closed on this stream update? When closed, volume and trade counter reset to zero and a new open price is set
     q: BigDecimal, // Quote asset volume
     V: BigDecimal, // Taker buy base asset volume
     Q: BigDecimal  // Taker buy quote asset volume

--- a/src/main/scala/io/github/paoloboni/binance/spot/SpotApi.scala
+++ b/src/main/scala/io/github/paoloboni/binance/spot/SpotApi.scala
@@ -264,7 +264,9 @@ final case class SpotApi[F[_]](
       stream <- client.ws[TradeStream](uri)
     } yield stream
 
-  /** The Kline/Candlestick Stream push updates to the current klines/candlestick every second.
+  /** The Kline/Candlestick Stream push updates to the current klines/candlestick periodically. 
+  In an actively traded symbol, the stream seems to push updates every two seconds. In a less actively traded symbol,
+  there may be longer gaps of 10 secs or more between updates, and updates intervals will not be regularly spaced.
     *
     * @param symbol
     *   the symbol

--- a/src/main/scala/io/github/paoloboni/binance/spot/SpotApi.scala
+++ b/src/main/scala/io/github/paoloboni/binance/spot/SpotApi.scala
@@ -264,9 +264,9 @@ final case class SpotApi[F[_]](
       stream <- client.ws[TradeStream](uri)
     } yield stream
 
-  /** The Kline/Candlestick Stream push updates to the current klines/candlestick periodically. 
-  In an actively traded symbol, the stream seems to push updates every two seconds. In a less actively traded symbol,
-  there may be longer gaps of 10 secs or more between updates, and updates intervals will not be regularly spaced.
+  /** The Kline/Candlestick Stream push updates to the current klines/candlestick periodically. In an actively traded
+    * symbol, the stream seems to push updates every two seconds. In a less actively traded symbol, there may be longer
+    * gaps of 10 secs or more between updates, and updates intervals will not be regularly spaced.
     *
     * @param symbol
     *   the symbol


### PR DESCRIPTION
Based on experiments. In quiet markets, the kline intervals are quite variable, I saw a 35sec interval once.

In active markets, Ive never seen 1 sec intervals myself, but rather 2.

Heres a sample taken today. The first number in each row is millis since last kline:
```
(2018,2.45504000,false,KLineStream(kline,1657370265160,BTCUSDT,KLineStreamPayload(1657370220000,1657370279999,BTCUSDT,1m,1446687073,1446689922,21503.89000000,21495.42000000,21519.87000000,21490.75000000,259.42782000,2850,false,5579178.36618170,133.24708000,2865653.04518890)))
(2023,0.40180000,false,KLineStream(kline,1657370267183,BTCUSDT,KLineStreamPayload(1657370220000,1657370279999,BTCUSDT,1m,1446687073,1446689950,21503.89000000,21492.96000000,21519.87000000,21490.75000000,259.82962000,2878,false,5587814.82516090,133.29038000,2866583.78481820)))
(2019,1.46218000,false,KLineStream(kline,1657370269202,BTCUSDT,KLineStreamPayload(1657370220000,1657370279999,BTCUSDT,1m,1446687073,1446690024,21503.89000000,21499.94000000,21519.87000000,21490.75000000,261.29180000,2952,false,5619246.18027680,134.64969000,2895803.82701350)))
(2014,2.48275000,false,KLineStream(kline,1657370271216,BTCUSDT,KLineStreamPayload(1657370220000,1657370279999,BTCUSDT,1m,1446687073,1446690093,21503.89000000,21499.04000000,21519.87000000,21490.75000000,263.77455000,3021,false,5672626.65410390,136.39953000,2933426.63723820)))
(2000,4.57743000,false,KLineStream(kline,1657370273216,BTCUSDT,KLineStreamPayload(1657370220000,1657370279999,BTCUSDT,1m,1446687073,1446690194,21503.89000000,21507.22000000,21519.87000000,21490.75000000,268.35198000,3122,false,5771059.61132180,139.72203000,3004872.69752490)))
(2003,3.26268000,false,KLineStream(kline,1657370275219,BTCUSDT,KLineStreamPayload(1657370220000,1657370279999,BTCUSDT,1m,1446687073,1446690280,21503.89000000,21507.05000000,21519.87000000,21490.75000000,271.61466000,3208,false,5841231.65359740,141.27102000,3038187.59180040)))
(2007,1.66010000,false,KLineStream(kline,1657370277226,BTCUSDT,KLineStreamPayload(1657370220000,1657370279999,BTCUSDT,1m,1446687073,1446690311,21503.89000000,21506.28000000,21519.87000000,21490.75000000,273.27476000,3239,false,5876935.10894870,141.77987000,3049131.45717560)))
(2133,0.71499000,false,KLineStream(kline,1657370279359,BTCUSDT,KLineStreamPayload(1657370220000,1657370279999,BTCUSDT,1m,1446687073,1446690334,21503.89000000,21506.74000000,21519.87000000,21490.75000000,273.98975000,3262,false,5892312.94614360,141.89837000,3051680.18246430)))
(645,0.08795000,true,KLineStream(kline,1657370280004,BTCUSDT,KLineStreamPayload(1657370220000,1657370279999,BTCUSDT,1m,1446687073,1446690375,21503.89000000,21507.78000000,21519.87000000,21490.75000000,274.07770000,3303,true,5894204.47244720,141.92535000,3052260.45902470)))
(2004,-242.65026000,false,KLineStream(kline,1657370282008,BTCUSDT,KLineStreamPayload(1657370280000,1657370339999,BTCUSDT,1m,1446690376,1446690648,21506.28000000,21514.35000000,21516.72000000,21505.67000000,31.42744000,273,false,676093.36808340,22.88742000,492382.99498700)))
(2192,5.48979000,false,KLineStream(kline,1657370284200,BTCUSDT,KLineStreamPayload(1657370280000,1657370339999,BTCUSDT,1m,1446690376,1446690776,21506.28000000,21512.63000000,21516.72000000,21505.67000000,36.91723000,401,false,794198.08319740,25.37101000,545813.14014220)))
(2002,3.36376000,false,KLineStream(kline,1657370286202,BTCUSDT,KLineStreamPayload(1657370280000,1657370339999,BTCUSDT,1m,1446690376,1446690814,21506.28000000,21512.00000000,21516.72000000,21505.67000000,40.28099000,439,false,866559.06520700,28.26700000,608111.46517580)))
(2015,1.76922000,false,KLineStream(kline,1657370288217,BTCUSDT,KLineStreamPayload(1657370280000,1657370339999,BTCUSDT,1m,1446690376,1446690868,21506.28000000,21510.80000000,21516.72000000,21505.67000000,42.05021000,493,false,904617.44189130,29.41176000,632736.96456930)))
(2043,9.40150000,false,KLineStream(kline,1657370290260,BTCUSDT,KLineStreamPayload(1657370280000,1657370339999,BTCUSDT,1m,1446690376,1446690986,21506.28000000,21507.05000000,21516.72000000,21505.13000000,51.45171000,611,false,1106814.56126700,30.45537000,655181.06756540)))
(2012,0.71975000,false,KLineStream(kline,1657370292272,BTCUSDT,KLineStreamPayload(1657370280000,1657370339999,BTCUSDT,1m,1446690376,1446691018,21506.28000000,21506.40000000,21516.72000000,21505.13000000,52.17146000,643,false,1122293.34107940,31.10775000,669210.95536450)))
(2078,0.14112000,false,KLineStream(kline,1657370294350,BTCUSDT,KLineStreamPayload(1657370280000,1657370339999,BTCUSDT,1m,1446690376,1446691047,21506.28000000,21505.30000000,21516.72000000,21505.13000000,52.31258000,672,false,1125328.30536610,31.15247000,670172.73502780)))
```