### PR TITLE
Attempt to fix e2e tests

### DIFF
--- a/src/e2e/scala/io/github/paoloboni/FapiE2ETests.scala
+++ b/src/e2e/scala/io/github/paoloboni/FapiE2ETests.scala
@@ -51,7 +51,7 @@ object FapiE2ETests extends BaseE2ETest[FutureApi[IO]] {
           symbol = "LTCUSDT",
           side = side,
           positionSide = FuturePositionSide.BOTH,
-          quantity = 10
+          quantity = 1
         )
       )
       .map(succeed)
@@ -66,7 +66,7 @@ object FapiE2ETests extends BaseE2ETest[FutureApi[IO]] {
             symbol = "LTCUSDT",
             side = side,
             positionSide = FuturePositionSide.BOTH,
-            quantity = 10
+            quantity = 1
           )
         )
       _ <- client
@@ -87,7 +87,7 @@ object FapiE2ETests extends BaseE2ETest[FutureApi[IO]] {
           side = OrderSide.BUY,
           positionSide = FuturePositionSide.BOTH,
           timeInForce = FutureTimeInForce.GTC,
-          quantity = 10,
+          quantity = 1,
           stopPrice = 2,
           price = 1.8
         )


### PR DESCRIPTION
In order to fix FAPI E2E test failures reporting "Margin is insufficient." I had to add funds to my mock trading account as explained [here](https://www.binance.com/en/support/faq/b3706b248f2b4b1caabb4bf253bf067f).
The changes in this PR are to minimise the probability to have to repeat this process again in the near future, by reducing the order amounts.