### PR TITLE
Attempt to make e2e tests more stable

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,7 @@ lazy val e2eSettings =
   inConfig(EndToEndTest)(Defaults.testSettings) ++
     Seq(
       EndToEndTest / fork              := true,
-      EndToEndTest / parallelExecution := false,
+      EndToEndTest / parallelExecution := true,
       EndToEndTest / scalaSource       := baseDirectory.value / "src" / "e2e" / "scala"
     )
 

--- a/src/e2e/scala/io/github/paoloboni/FapiE2ETests.scala
+++ b/src/e2e/scala/io/github/paoloboni/FapiE2ETests.scala
@@ -8,6 +8,7 @@ import io.github.paoloboni.binance.fapi._
 import io.github.paoloboni.binance.fapi.parameters._
 
 import java.time.Instant
+import scala.concurrent.duration.Duration
 import scala.util.Random
 
 object FapiE2ETests extends BaseE2ETest[FutureApi[IO]] {
@@ -80,7 +81,7 @@ object FapiE2ETests extends BaseE2ETest[FutureApi[IO]] {
   }
 
   test("cancelOrder") { client =>
-    for {
+    (for {
       createOrderResponse <- client.createOrder(
         FutureOrderCreateParams.STOP(
           symbol = "XRPUSDT",
@@ -100,11 +101,11 @@ object FapiE2ETests extends BaseE2ETest[FutureApi[IO]] {
           origClientOrderId = None
         )
       )
-    } yield success
+    } yield success).retryWithBackoff(initialDelay = Duration.Zero)
   }
 
   test("cancelAllOrders") { client =>
-    for {
+    (for {
       _ <- client.createOrder(
         FutureOrderCreateParams.LIMIT(
           symbol = "XRPUSDT",
@@ -119,7 +120,7 @@ object FapiE2ETests extends BaseE2ETest[FutureApi[IO]] {
       _ <- client.cancelAllOrders(
         FutureOrderCancelAllParams(symbol = "XRPUSDT")
       )
-    } yield success
+    } yield success).retryWithBackoff(initialDelay = Duration.Zero)
   }
 
   test("aggregateTradeStreams") {

--- a/src/e2e/scala/io/github/paoloboni/SpotE2ETests.scala
+++ b/src/e2e/scala/io/github/paoloboni/SpotE2ETests.scala
@@ -9,7 +9,7 @@ import io.github.paoloboni.binance.spot._
 import io.github.paoloboni.binance.spot.parameters._
 
 import java.time.Instant
-import scala.concurrent.duration.DurationInt
+import scala.concurrent.duration.{Duration, DurationInt}
 import scala.util.Random
 
 object SpotE2ETests extends BaseE2ETest[SpotApi[IO]] {
@@ -79,7 +79,7 @@ object SpotE2ETests extends BaseE2ETest[SpotApi[IO]] {
 
   test("cancelOrder") { client =>
     val symbol = "TRXUSDT"
-    for {
+    (for {
       createOrderResponse <- client.createOrder(
         SpotOrderCreateParams.LIMIT(
           symbol = symbol,
@@ -98,13 +98,12 @@ object SpotE2ETests extends BaseE2ETest[SpotApi[IO]] {
             origClientOrderId = None
           )
         )
-        .retryWithBackoff(initialDelay = 200.millis)
-    } yield success
+    } yield success).retryWithBackoff(initialDelay = Duration.Zero)
   }
 
   test("cancelAllOrders") { client =>
     val symbol = "TRXUSDT"
-    for {
+    (for {
       _ <- client.createOrder(
         SpotOrderCreateParams.LIMIT(
           symbol = symbol,
@@ -119,8 +118,7 @@ object SpotE2ETests extends BaseE2ETest[SpotApi[IO]] {
         .cancelAllOrders(
           SpotOrderCancelAllParams(symbol = symbol)
         )
-        .retryWithBackoff(initialDelay = 200.millis)
-    } yield success
+    } yield success).retryWithBackoff(initialDelay = Duration.Zero)
   }
 
   test("tradeStreams") {


### PR DESCRIPTION
- "Cancel order" tests are flaky, because sometimes the newly created order is filled before it's cancelled. Its status should be "NEW" at the time the cancellation is attempted [1]
- Run e2e tests in parallel

[1] https://dev.binance.vision/t/2011-unknown-order-sent-error-for-cancel-all-open-orders-on-a-symbol-endpoint/376/2