### PR TITLE
Human readable aliases for single-letter Binance fields

### DIFF
--- a/src/main/scala/io/github/paoloboni/binance/common/response/KLineStream.scala
+++ b/src/main/scala/io/github/paoloboni/binance/common/response/KLineStream.scala
@@ -46,4 +46,8 @@ case class KLineStream(
     E: Long,   // Event time
     s: String, // Symbol
     k: KLineStreamPayload
-)
+) {
+    def eventType: String = e
+    def eventTime: Long = E
+    def symbol: String = s
+}


### PR DESCRIPTION
Hi @paoloboni would you be open to (gradually) annotating the response classes with human-readable aliases as per this PR?

I totally agree that aligning with the Binance docs is right for the core model, but for client-code that couples against the response classes, the single letter fields are cryptic and hurt code readability.

I dont have the motivation to do them all at once, but I would like to contribute them gradually as I have the need. I'll end up writing extension methods myself otherwise, and thats a shame, it'd be better to share the work.