### PR TITLE
Add GTD (Good Till Date) to FutureTimeInForce Enum

### DIFF
--- a/src/main/scala-2/io/github/paoloboni/binance/fapi/FutureTimeInForce.scala
+++ b/src/main/scala-2/io/github/paoloboni/binance/fapi/FutureTimeInForce.scala
@@ -31,4 +31,5 @@ object FutureTimeInForce extends Enum[FutureTimeInForce] with CirceEnum[FutureTi
   case object IOC extends FutureTimeInForce // Immediate or Cancel
   case object FOK extends FutureTimeInForce // Fill or Kill
   case object GTX extends FutureTimeInForce // Good Till Crossing (Post Only)
+  case object GTD extends FutureTimeInForce // Good Till Date
 }

--- a/src/main/scala-3/io/github/paoloboni/binance/fapi/FutureTimeInForce.scala
+++ b/src/main/scala-3/io/github/paoloboni/binance/fapi/FutureTimeInForce.scala
@@ -25,4 +25,4 @@ import io.circe.Decoder
 import io.github.paoloboni.binance.common.EnumDecoder
 
 enum FutureTimeInForce derives EnumDecoder:
-  case GTC, IOC, FOK, GTX
+  case GTC, IOC, FOK, GTX, GTD


### PR DESCRIPTION
This PR adds the **GTD** case to the `FutureTimeInForce` enum. Prior to this change, using the Binance Futures Client resulted in a deserialization exception when encountering the 'GTD' time in force. The exception details are as follows:

```
[error] sttp.client3.DeserializationException: Failed to decode GTD: MoveRight,MoveRight,MoveRight,MoveRight,DownArray,DownField(timeInForce),DownArray,DownField(symbols)
[error] 	at sttp.client3.DeserializationException$.apply(ResponseAs.scala:229)
[error] 	at sttp.client3.ResponseAs$.deserializeWithError$$anonfun$1(ResponseAs.scala:201)
[error] 	at sttp.client3.ResponseAs$.deserializeRightWithError$$anonfun$1(ResponseAs.scala:180)
[error] 	at sttp.client3.MappedResponseAs.mapWithMetadata$$anonfun$1(ResponseAs.scala:91)
[error] 	at sttp.client3.internal.BodyFromResponseAs.doApply$$anonfun$2(BodyFromResponseAs.scala:24)
[error] 	at use @ BotApp$.run(BotApp.scala:33)
[error] 	at flatMap @ fs2.Compiler$Target.flatMap(Compiler.scala:162)
[error] 	at flatMap @ fs2.Compiler$Target.flatMap(Compiler.scala:162)
[error] 	at flatMap @ fs2.Compiler$Target.flatMap(Compiler.scala:162)
[error] 	at flatMap @ fs2.Compiler$Target.flatMap(Compiler.scala:162)
[error] 	at flatMap @ fs2.Compiler$Target.flatMap(Compiler.scala:162)
[error] 	at flatMap @ fs2.Compiler$Target.flatMap(Compiler.scala:162)
[error] 	at modify @ fs2.internal.Scope.close(Scope.scala:262)
[error] 	at flatMap @ fs2.Compiler$Target.flatMap(Compiler.scala:162)
[error] 	at rethrow$extension @ fs2.Compiler$Target.compile$$anonfun$1(Compiler.scala:156)
[error] 	at run$ @ BotApp$.run(BotApp.scala:12)
[error] 	at get @ fs2.internal.Scope.openScope(Scope.scala:281)
[error] 	at flatMap @ fs2.Compiler$Target.flatMap(Compiler.scala:162)
[error] 	at flatMap @ fs2.Pull$.goCloseScope$1$$anonfun$1$$anonfun$3(Pull.scala:1187)
[error] 	at update @ fs2.internal.Scope.releaseChildScope(Scope.scala:227)
[error] 	at flatMap @ fs2.Compiler$Target.flatMap(Compiler.scala:162)
[error] stack trace is suppressed; run last Compile / run for the full output
[error] (Compile / run) sttp.client3.DeserializationException: Failed to decode GTD: MoveRight,MoveRight,MoveRight,MoveRight,DownArray,DownField(timeInForce),DownArray,DownField(symbols)
```

<img width="2055" alt="Screenshot 2023-12-25 at 13 51 37" src="https://github.com/paoloboni/binance-scala-client/assets/36740575/126438af-3dac-4cba-acb6-9d9dfaece217">
